### PR TITLE
[Fix][Issue #19] Update do_drop.mcfunction

### DIFF
--- a/data/explosion_rebuilder/functions/do_drop.mcfunction
+++ b/data/explosion_rebuilder/functions/do_drop.mcfunction
@@ -3,4 +3,4 @@ execute positioned 29999987 5 259 unless block ~ ~ ~ #explosion_rebuilder:nbt ru
 execute positioned 29999987 5 259 if block ~ ~ ~ #explosion_rebuilder:nbt run fill ~ ~ ~ ~ ~ ~ minecraft:air destroy
 execute positioned 29999987 5 259 run tp @e[type=item,distance=..3] @s
 
-say hi
+#say hi


### PR DESCRIPTION
Fixed the error which outputs the message "[Marker] hi" after rebuilding the blocks destroyed by a creeper.